### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/Source/Cake.Email.Tests/Cake.Email.Tests.csproj
+++ b/Source/Cake.Email.Tests/Cake.Email.Tests.csproj
@@ -32,12 +32,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.16.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.16.2\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Cake.Testing, Version=0.16.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Testing.0.16.2\lib\net45\Cake.Testing.dll</HintPath>
+    <Reference Include="Cake.Testing, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Testing.0.17.1\lib\net45\Cake.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">

--- a/Source/Cake.Email.Tests/packages.config
+++ b/Source/Cake.Email.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.16.2" targetFramework="net452" />
-  <package id="Cake.Testing" version="0.16.2" targetFramework="net452" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net452" />
+  <package id="Cake.Testing" version="0.17.1" targetFramework="net452" />
   <package id="gep13.xUnitRunner" version="0.1.1" targetFramework="net452" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />

--- a/Source/Cake.Email/Cake.Email.csproj
+++ b/Source/Cake.Email/Cake.Email.csproj
@@ -36,12 +36,12 @@
     <CodeAnalysisRuleSet>Cake.Email.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Common, Version=0.16.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Common.0.16.2\lib\net45\Cake.Common.dll</HintPath>
+    <Reference Include="Cake.Common, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Common.0.17.0\lib\net45\Cake.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Cake.Core, Version=0.16.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.16.2\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Source/Cake.Email/packages.config
+++ b/Source/Cake.Email/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Common" version="0.16.2" targetFramework="net452" />
-  <package id="Cake.Core" version="0.16.2" targetFramework="net452" />
+  <package id="Cake.Common" version="0.17.0" targetFramework="net452" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net452" />
   <package id="gep13.ApplicationRunner" version="0.1.2" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.