### PR TITLE
Updated documentation to use the updated alias

### DIFF
--- a/docs/input/docs/usage/examples.md
+++ b/docs/input/docs/usage/examples.md
@@ -14,7 +14,7 @@ Task("SendEmail")
                 Email.CreateAttachmentFromLocalFile("C:\\temp\\MySpreadsheet.xls"),
                 Email.CreateAttachmentFromLocalFile("C:\\temp\\MyFile.pdf"),
         };
-        var result = Email.Send(
+        var result = Email.SendEmail(
                 senderName: "Bob Smith", 
                 senderAddress: "bob@example.com",
                 recipientName: "Jane Doe",
@@ -65,7 +65,7 @@ Task("SendEmail")
                 Email.CreateAttachmentFromLocalFile("C:\\temp\\MySpreadsheet.xls"),
                 Email.CreateAttachmentFromLocalFile("C:\\temp\\MyFile.pdf"),
         };
-        var result = Email.Send(
+        var result = Email.SendEmail(
                 senderName: "Bob Smith", 
                 senderAddress: "bob@example.com",
                 recipients: new[]


### PR DESCRIPTION
Looks like Email.Send was replaced with Email.SendEmail as per documentation in EmailProvider.cs